### PR TITLE
Fixes for CMake args as set by base brew Formula

### DIFF
--- a/core-moos.rb
+++ b/core-moos.rb
@@ -13,7 +13,7 @@ class CoreMoos < Formula
     
     
     def install
-        cmake_args = std_cmake_args.split
+        cmake_args = std_cmake_args
         
         cmake_args << "-DUSE_AYSNC_COMMS:BOOL=ON"
         

--- a/core-moos.rb
+++ b/core-moos.rb
@@ -13,7 +13,7 @@ class CoreMoos < Formula
     
     
     def install
-        cmake_args = std_cmake_parameters.split
+        cmake_args = std_cmake_args.split
         
         cmake_args << "-DUSE_AYSNC_COMMS:BOOL=ON"
         

--- a/essential-moos.rb
+++ b/essential-moos.rb
@@ -12,7 +12,7 @@ class EssentialMoos < Formula
     
 
   def install
-      cmake_args = std_cmake_parameters.split
+      cmake_args = std_cmake_args
       system "cmake", ".", *cmake_args
       system "make"
       system "make install"

--- a/ui-moos.rb
+++ b/ui-moos.rb
@@ -14,7 +14,7 @@ class UiMoos < Formula
     
     
     def install
-        cmake_args = std_cmake_parameters.split
+        cmake_args = std_cmake_args
         cmake_args << "-DBUILD_GRAPHICAL_TOOLS:BOOL=ON"
         cmake_args << "-DBUILD_UMS:BOOL=ON"
         cmake_args << "-DBUILD_UPB:BOOL=ON"


### PR DESCRIPTION
```std_cmake_parameters``` is deprecated.
```std_cmake_args``` replaces it as an (already split) list.